### PR TITLE
Spring Boot 1.5.3 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ mvnw
 .mvn/wrapper/maven-wrapper.jar
 
 mvnw.cmd
+
+node_modules/
+src/main/resources/static/built/

--- a/pom.xml
+++ b/pom.xml
@@ -14,20 +14,20 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>1.5.3.RELEASE</version>
         <relativePath/>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <hibernate.version>5.2.6.Final</hibernate.version>
+        <hibernate.version>5.2.10.Final</hibernate.version>
         <java.version>1.8</java.version>
-        <jackson.version>2.8.6</jackson.version>
+        <jackson.version>2.8.8</jackson.version>
         <javax.inject.version>1</javax.inject.version>
         <commons-io.version>2.5</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>
-        <HikariCP.version>2.6.0</HikariCP.version>
+        <HikariCP.version>2.6.1</HikariCP.version>
     </properties>
 
     <dependencies>
@@ -55,6 +55,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
         <!--****************** SQL *******************-->
@@ -142,6 +146,13 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.6.2</version>
+        </dependency>
+
+        <!--****************** BOOTSTRAP *******************-->
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>bootstrap</artifactId>
+            <version>3.3.7-1</version>
         </dependency>
 
         <!--****************** TESTING *******************-->

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -41,3 +41,9 @@ server:
         enabled: true
         mime-types: text/html,text/xml,text/plain,text/css, application/javascript, application/json
         min-response-size: 1024
+management:
+  port: 8090
+  context-path: /management
+  security:
+    enabled: false
+#    roles: ADMIN


### PR DESCRIPTION
1. Added `Spring Boot Actuator` dependency
2. Updated `Spring Boot` to 1.5.3 ver
3. Updated `Hibernate` to 5.2.10 ver
4. Updated `HikariCP` to 2.6.1 ver
